### PR TITLE
upgrade pangeo-notebook base to 2024-06-02, refs #8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pangeo-notebook:2024.04.05
+FROM pangeo/pangeo-notebook:2024.06.02
 
 USER root
 

--- a/image-tests/test-notebook.ipynb
+++ b/image-tests/test-notebook.ipynb
@@ -314,7 +314,7 @@
     },
     "nbreg": {
      "diff_ignore": [
-      "/outputs/3/data"
+      "/outputs"
      ]
     }
    },
@@ -1110,6 +1110,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.8"
+  },
+  "nbreg": {
+   "diff_ignore": [
+    "/metadata/language_info"
+   ]
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #8 

Updates pangeo-notebook base to 2024-06-02

The Action fails: https://github.com/NASA-IMPACT/pangeo-notebook-veda-image/actions/runs/9609542002/job/26504214731

I think there's two things going on:

I see this error from pip around some dependency resolution:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
  cattrs 23.2.3 requires attrs>=23.1.0, but you have attrs 22.2.0 which is incompatible.
```

I think we might need to look into that? cc @sunu 

The tests "fail", but from a quick eye-balling of the failures, it seems like this should all be expected things after version upgrades - version numbers changing, some changes to JS / CSS, etc. 

@jsignell if the test failures all seem kosher and nothing unexpected, we can just probably re-generate the notebook and outputs: https://github.com/NASA-IMPACT/pangeo-notebook-veda-image?tab=readme-ov-file#adding-new-tests - I probably won't get to this today, but if you're unable to get to it, I and @sunu can probably look early next week.

