### PR TITLE
Add image source OCI label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM pangeo/pangeo-notebook:2024.06.02
 
+LABEL org.opencontainers.image.source="https://github.com/nasa-impact/pangeo-notebook-veda-image"
+
 USER root
 
 COPY --chown=${NB_USER}:${NB_USER} image-tests /srv/repo/image-tests


### PR DESCRIPTION
Adds this repository address to the Docker image metadata. This should make it easier for anyone using the image to trace it back to its source code.