### PR TITLE
Add changes needed for jupyter-sshd-proxy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,11 @@ channels:
   - defaults
 dependencies:
   - ipykernel
+  - openssh
   - pip
   - pip:
     - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.3#egg-info=stac_ipyleaflet
+    - jupyter-sshd-proxy
 variables:
   TITILER_STAC_ENDPOINT: 'https://staging-stac.delta-backend.com'
   TITILER_ENDPOINT: 'https://staging-raster.delta-backend.com'

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,10 @@ channels:
   - defaults
 dependencies:
   - ipykernel
-  - openssh
+  - jupyter-sshd-proxy
   - pip
   - pip:
     - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.3#egg-info=stac_ipyleaflet
-    - jupyter-sshd-proxy
 variables:
   TITILER_STAC_ENDPOINT: 'https://staging-stac.delta-backend.com'
   TITILER_ENDPOINT: 'https://staging-raster.delta-backend.com'


### PR DESCRIPTION
Allows users to ssh in, sftp / scp for copying files, sshfs to work on files locally, and use the 
proprietary vscode remote ssh feature!