### PR TITLE
Disable default conda channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - ipykernel
   # Dependencies for VS Code IDE


### PR DESCRIPTION
We don't want to use the default channels because of their licensing