### PR TITLE
Update URLs to openveda.cloud and bump stac_ipyleaflet

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,4 @@ variables:
   TITILER_ENDPOINT: 'https://openveda.cloud/api/raster'
   STAC_CATALOG_NAME: 'VEDA STAC'
   STAC_CATALOG_URL: 'https://openveda.cloud/api/stac'
-  STAC_BROWSER_URL: 'http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com/'
+  STAC_BROWSER_URL: 'https://openveda.cloud/'

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - openssh
   - pip
   - pip:
-    - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.3#egg-info=stac_ipyleaflet
+    - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.6
     - jupyter-sshd-proxy
     - jupyterlab-bxplorer
 variables:

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
     - jupyter-sshd-proxy
     - jupyterlab-bxplorer
 variables:
-  TITILER_STAC_ENDPOINT: 'https://staging-stac.delta-backend.com'
-  TITILER_ENDPOINT: 'https://staging-raster.delta-backend.com'
+  TITILER_STAC_ENDPOINT: 'https://openveda.cloud/api/stac'
+  TITILER_ENDPOINT: 'https://openveda.cloud/api/raster'
   STAC_CATALOG_NAME: 'VEDA STAC'
-  STAC_CATALOG_URL: 'https://staging-stac.delta-backend.com/'
+  STAC_CATALOG_URL: 'https://openveda.cloud/api/stac'
   STAC_BROWSER_URL: 'http://veda-staging-stac-browser.s3-website-us-west-2.amazonaws.com/'


### PR DESCRIPTION
The endpoints have migrated, this PR updates the environment variables that contain those URLs. Also bumps stac_ipyleaflet so that the VEDA tutorials run successfully.