### PR TITLE
Upgrade: Pangeo version bump to 2024-11-11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pangeo-notebook:2024.08.18
+FROM pangeo/pangeo-notebook:2024.11.11
 
 LABEL org.opencontainers.image.source="https://github.com/nasa-impact/pangeo-notebook-veda-image"
 


### PR DESCRIPTION
Addressing #30 
I've tested loading in https://staging.hub.openveda.cloud using public.ecr.aws/nasa-veda/pangeo-notebook-veda-image:c76b967c7648

Any particular things to test once it's booted?