### PR TITLE
Pin code-server

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - ipykernel
   # Dependencies for VS Code IDE
-  - code-server>=3.2
+  - code-server>=3.2,<=4.96.4
   - jupyter-vscode-proxy
   - openssh
   - pre_commit


### PR DESCRIPTION
The latest version of code-server does not work on the Hub. This PR temporarily pins to prior versions.