### PR TITLE
Add plotly dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - jupyter-vscode-proxy
   - openssh
   - pre_commit
+  - plotly
   - pip
   - pip:
     - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.6


### PR DESCRIPTION
To support each VEDA Data story, notebooks will be created which will allow for users to better visualize specific datasets. Plotly is needed to support a dual-slider visual within the first notebook that will be added to veda-docs.