### PR TITLE
Do not run github actions on PRs

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -10,9 +10,6 @@ on:
     paths-ignore:
       - "README.md"
       - "LICENSE"
-  pull_request:
-    branches:
-      - main
 
 env:
   REGISTRY: public.ecr.aws
@@ -33,7 +30,6 @@ jobs:
         install: true
 
     - name: Configure AWS Credentials
-      if: github.event_name == 'push'
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -41,14 +37,12 @@ jobs:
         aws-region: us-east-1
 
     - name: Login to Amazon ECR Public
-      if: github.event_name == 'push'
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
       with:
         registry-type: public
 
     - uses: int128/create-ecr-repository-action@v1
-      if: github.event_name == 'push'
       with:
         repository: ${{ env.IMAGE_NAME}}
         public: true


### PR DESCRIPTION
This PR reverts #5. The only reason to run actions on PR is to allow CI to run on PRs from forks, but that's not necessary for this repo. It's redundant to run the exact same CI twice and it's confusing that only actions that are triggered by push events end up pushing the image to docker. 