### PR TITLE
upgrade pangeo-notebook to 2026.06.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pangeo-notebook:2026.05.29
+FROM pangeo/pangeo-notebook:2026.06.04
 
 LABEL org.opencontainers.image.source="https://github.com/nasa-impact/pangeo-notebook-veda-image"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pangeo/pangeo-notebook:2025.12.30
+FROM pangeo/pangeo-notebook:2026.05.29
 
 LABEL org.opencontainers.image.source="https://github.com/nasa-impact/pangeo-notebook-veda-image"
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,14 +8,14 @@ dependencies:
   - jupyter-vscode-proxy
   - openssh
   - pre_commit
-  # Add arbalister to render parquet
-  - arbalister
   # Upgrade from pangeo-notebook image
   - earthaccess>=0.16.0
   # Pin down to avoid https://github.com/holoviz/pyviz_comms/issues/143
   - pyviz_comms==3.0.4
   - pip
   - pip:
+    # Install via pip to avoid conda datafusion/libabseil solver conflicts with py3.12.
+    - arbalister
     - jupyter-sshd-proxy
     - jupyterlab-bxplorer
 variables:


### PR DESCRIPTION
Update to use latest pangeo notebook image for zarr and icechunk upgrades. Tested against icechunk v2 stores. This also updates python to 3.13

Note, due to conflicts into the solver with the latest updates and arbalister I've move arbalister to pip install. Using a locally built image, I was able to still render parquet items through arbalister