### PR TITLE
workflow rules updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
       day: "monday"
       time: "03:00"
       timezone: "UTC"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
-      day: "monday"
       time: "03:00"
       timezone: "UTC"
     cooldown:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -2,6 +2,12 @@ name: Build and push container image
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
   push:
     branches:
       - "**" # Push to any branch
@@ -32,6 +38,7 @@ jobs:
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Configure AWS Credentials
+      if: github.actor != 'dependabot[bot]'
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -39,12 +46,14 @@ jobs:
         aws-region: us-east-1
 
     - name: Login to Amazon ECR Public
+      if: github.actor != 'dependabot[bot]'
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
       with:
         registry-type: public
 
     - uses: int128/create-ecr-repository-action@c1b18173fe6f1285019539f07583f568bc304154 # v1.99.0
+      if: github.actor != 'dependabot[bot]'
       with:
         repository: ${{ env.IMAGE_NAME}}
         public: true
@@ -67,7 +76,7 @@ jobs:
         fi
 
     - name: Tag and push image
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
       env:
         IMAGE_TAG: ${{ steps.set_tag.outputs.IMAGE_TAG }}
         GITHUB_REF_NAME: ${{ github.ref }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: github.actor != 'dependabot[bot]'
     steps:
     - name: Checkout repository
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -38,7 +39,6 @@ jobs:
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Configure AWS Credentials
-      if: github.actor != 'dependabot[bot]'
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -46,14 +46,12 @@ jobs:
         aws-region: us-east-1
 
     - name: Login to Amazon ECR Public
-      if: github.actor != 'dependabot[bot]'
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
       with:
         registry-type: public
 
     - uses: int128/create-ecr-repository-action@c1b18173fe6f1285019539f07583f568bc304154 # v1.99.0
-      if: github.actor != 'dependabot[bot]'
       with:
         repository: ${{ env.IMAGE_NAME}}
         public: true
@@ -76,7 +74,7 @@ jobs:
         fi
 
     - name: Tag and push image
-      if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
+      if: github.event_name == 'push'
       env:
         IMAGE_TAG: ${{ steps.set_tag.outputs.IMAGE_TAG }}
         GITHUB_REF_NAME: ${{ github.ref }}


### PR DESCRIPTION
Secrets aren't passed for dependabot, updates CI to not run on dependabot triggered PRs

Additionally, to be a bit less noisy, I've moved the github action frequency from weekly to quarterly

Relevant to: https://github.com/NASA-IMPACT/pangeo-notebook-veda-image/pull/71